### PR TITLE
profile feature and master branch on the same CI job

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -41,11 +41,43 @@ jobs:
         run: |
           if [[ "$ENABLE_PROFILER" == 'true' ]]; then
             steps=("ecm_prep" "run")
+
+            # --- Profile the feature branch first ---
             for step in "${steps[@]}"; do
               psrecord --log memory_log_${step}.txt --include-children --interval 1 "python tests/integration_testing/run_workflow.py --run_step $step --yaml tests/integration_testing/integration_test.yml --with_profiler"
               (echo -e; echo "# Elapsed time,CPU (%),Peak Real (MB),Peak Virtual (MB)"; grep -v "time" memory_log_${step}.txt | sort -k3 -n -r | head -n 1 | column -t | tr -s '[:blank:]' ',') >> results/profile_${step}.csv
               mv memory_log_${step}.txt ./results/
             done
+
+            # --- Checkout master and profile it for baseline comparison ---
+            git fetch --depth=1 origin master
+            git stash  # stash any result files to avoid conflicts
+            git checkout origin/master -- .
+            pip install -c .github/constraints.txt ".[dev]" psrecord --quiet
+
+            mkdir -p results_master
+            for step in "${steps[@]}"; do
+              psrecord --log memory_log_master_${step}.txt --include-children --interval 1 "python tests/integration_testing/run_workflow.py --run_step $step --yaml tests/integration_testing/integration_test.yml --with_profiler"
+              (echo -e; echo "# Elapsed time,CPU (%),Peak Real (MB),Peak Virtual (MB)"; grep -v "time" memory_log_master_${step}.txt | sort -k3 -n -r | head -n 1 | column -t | tr -s '[:blank:]' ',') >> results_master/profile_${step}.csv
+              mv memory_log_master_${step}.txt ./results_master/
+            done
+
+            # --- Restore feature branch code ---
+            git checkout ${{ github.event.pull_request.head.sha || github.sha }} -- .
+            pip install -c .github/constraints.txt ".[dev]" psrecord --quiet
+
+            # --- Write comparison summary ---
+            echo "=== Profiling Comparison ===" | tee results/profile_comparison.txt
+            for step in "${steps[@]}"; do
+              echo "--- Step: $step ---" | tee -a results/profile_comparison.txt
+              echo "Master:  $(tail -1 results_master/profile_${step}.csv)" | tee -a results/profile_comparison.txt
+              echo "Feature: $(tail -1 results/profile_${step}.csv)" | tee -a results/profile_comparison.txt
+            done
+
+            # Move master profiling logs into results so they get uploaded as artifacts
+            mv results_master/memory_log_master_*.txt ./results/ 2>/dev/null || true
+            mv results_master/profile_*.csv ./results/profile_master_ecm_prep.csv 2>/dev/null || true
+
           else
             python tests/integration_testing/run_workflow.py --yaml tests/integration_testing/integration_test.yml
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -40,44 +40,61 @@ jobs:
           ENABLE_PROFILER: ${{ inputs.enable_profiler || (github.ref == 'refs/heads/master') }}
           SOURCE_DATE_EPOCH: '0'
         run: |
+          mkdir -p results
           if [[ "$ENABLE_PROFILER" == 'true' ]]; then
             steps=("ecm_prep" "run")
 
-            # --- Profile the feature branch first ---
+            # --- Profile FEATURE branch ---
+            # Clear ecm_prep cache so the feature branch starts from a cold cache
+            rm -rf generated/ecm_competition_data/*.pkl.gz
+            rm -f  generated/ecm_prep.json
+
             for step in "${steps[@]}"; do
-              psrecord --log memory_log_${step}.txt --include-children --interval 1 "python tests/integration_testing/run_workflow.py --run_step $step --yaml tests/integration_testing/integration_test.yml --with_profiler"
-              (echo -e; echo "# Elapsed time,CPU (%),Peak Real (MB),Peak Virtual (MB)"; grep -v "time" memory_log_${step}.txt | sort -k3 -n -r | head -n 1 | column -t | tr -s '[:blank:]' ',') >> results/profile_${step}.csv
-              mv memory_log_${step}.txt ./results/
-              # Save feature profile before master run overwrites results/
-              cp results/profile_${step}.csv results/profile_feature_${step}.csv
+              log_file="memory_log_feature_${step}.txt"
+
+              psrecord --log "$log_file" --include-children --interval 1 \
+                "python tests/integration_testing/run_workflow.py --run_step $step --yaml tests/integration_testing/integration_test.yml --with_profiler"
+
+              # run_workflow.py writes cProfile stats to results/profile_${step}.csv — rename with branch suffix
+              mv "results/profile_${step}.csv" "results/profile_${step}_feature.csv"
+              mv "$log_file" "results/memory_log_${step}_feature.txt"
             done
 
-            # --- Checkout master and profile it for baseline comparison ---
+            # --- Checkout master ---
             git fetch --depth=1 origin master
-            git stash  # stash any result files to avoid conflicts
             git checkout origin/master -- .
             pip install -c .github/constraints.txt ".[dev]" psrecord --quiet
 
-            mkdir -p results_master
+            # --- Profile MASTER branch ---
+            # Clear cache so master also starts from a cold cache
+            rm -rf generated/ecm_competition_data/*.pkl.gz
+            rm -f  generated/ecm_prep.json
+
             for step in "${steps[@]}"; do
-              psrecord --log memory_log_master_${step}.txt --include-children --interval 1 "python tests/integration_testing/run_workflow.py --run_step $step --yaml tests/integration_testing/integration_test.yml --with_profiler"
-              (echo -e; echo "# Elapsed time,CPU (%),Peak Real (MB),Peak Virtual (MB)"; grep -v "time" memory_log_master_${step}.txt | sort -k3 -n -r | head -n 1 | column -t | tr -s '[:blank:]' ',') >> results_master/profile_${step}.csv
-              mv memory_log_master_${step}.txt ./results_master/
+              log_file="memory_log_master_${step}.txt"
+
+              psrecord --log "$log_file" --include-children --interval 1 \
+                "python tests/integration_testing/run_workflow.py --run_step $step --yaml tests/integration_testing/integration_test.yml --with_profiler"
+
+              # Rename cProfile CSV and memory log with branch suffix
+              mv "results/profile_${step}.csv" "results/profile_${step}_master.csv"
+              mv "$log_file" "results/memory_log_${step}_master.txt"
             done
 
-            # --- Restore feature branch code ---
+            # --- Restore feature branch ---
             git checkout ${{ github.event.pull_request.head.sha || github.sha }} -- .
             pip install -c .github/constraints.txt ".[dev]" psrecord --quiet
 
-            # --- Write comparison summary ---
+            # --- Comparison ---
             echo "=== Profiling Comparison ===" | tee results/profile_comparison.txt
+
             for step in "${steps[@]}"; do
               echo "" | tee -a results/profile_comparison.txt
               echo "--- Step: $step ---" | tee -a results/profile_comparison.txt
 
               # Elapsed time = col 1 of the last data row of each psrecord memory log
-              m_time=$(grep -v "^#" "results/memory_log_master_${step}.txt" | grep -v "^$" | tail -n 1 | awk '{print $1}')
-              f_time=$(grep -v "^#" "results/memory_log_${step}.txt"        | grep -v "^$" | tail -n 1 | awk '{print $1}')
+              m_time=$(grep -v "^#" "results/memory_log_${step}_master.txt"  | grep -v "^$" | tail -n 1 | awk '{print $1}')
+              f_time=$(grep -v "^#" "results/memory_log_${step}_feature.txt" | grep -v "^$" | tail -n 1 | awk '{print $1}')
 
               echo "Master  elapsed time: ${m_time}s" | tee -a results/profile_comparison.txt
               echo "Feature elapsed time: ${f_time}s" | tee -a results/profile_comparison.txt
@@ -89,18 +106,13 @@ jobs:
               fi
             done
 
-            # Move master profiling logs into results so they get uploaded as artifacts
-            mv results_master/memory_log_master_*.txt ./results/ 2>/dev/null || true
-            for step in "${steps[@]}"; do
-              mv results_master/profile_${step}.csv ./results/profile_master_${step}.csv 2>/dev/null || true
-            done
-
           else
             python tests/integration_testing/run_workflow.py --yaml tests/integration_testing/integration_test.yml
           fi
+
           rm -rf ./tests/integration_testing/results/*
           mv ./results/* ./tests/integration_testing/results/
-          mv ./generated/log_*.txt ./tests/integration_testing/results/ 2>/dev/null
+          mv ./generated/log_*.txt ./tests/integration_testing/results/ 2>/dev/null || true
       - name: Capture profiler comparison output
         id: profile_comparison
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -499,7 +499,7 @@ jobs:
                 const fTime = fMatch ? fMatch[1] : 'N/A';
                 const absDiff = dMatch ? dMatch[1] : 'N/A';
                 const pct = dMatch ? dMatch[2] : 'N/A';
-                const icon = dMatch ? (parseFloat(dMatch[2]) >= 0 ? '✅' : '⚠️') : '';
+                const icon = dMatch ? (parseFloat(dMatch[2]) > 0.005 ? '✅' : '⚠️') : '';
                 body += `| \`${stepName}\` | ${mTime} | ${fTime} | ${absDiff} | ${icon} ${pct}% |\n`;
               }
               body += `\n<details><summary>Full profiler output</summary>\n\n`;

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,6 +47,8 @@ jobs:
               psrecord --log memory_log_${step}.txt --include-children --interval 1 "python tests/integration_testing/run_workflow.py --run_step $step --yaml tests/integration_testing/integration_test.yml --with_profiler"
               (echo -e; echo "# Elapsed time,CPU (%),Peak Real (MB),Peak Virtual (MB)"; grep -v "time" memory_log_${step}.txt | sort -k3 -n -r | head -n 1 | column -t | tr -s '[:blank:]' ',') >> results/profile_${step}.csv
               mv memory_log_${step}.txt ./results/
+              # Save feature profile before master run overwrites results/
+              cp results/profile_${step}.csv results/profile_feature_${step}.csv
             done
 
             # --- Checkout master and profile it for baseline comparison ---
@@ -71,12 +73,14 @@ jobs:
             for step in "${steps[@]}"; do
               echo "--- Step: $step ---" | tee -a results/profile_comparison.txt
               echo "Master:  $(tail -1 results_master/profile_${step}.csv)" | tee -a results/profile_comparison.txt
-              echo "Feature: $(tail -1 results/profile_${step}.csv)" | tee -a results/profile_comparison.txt
+              echo "Feature: $(tail -1 results/profile_feature_${step}.csv)" | tee -a results/profile_comparison.txt
             done
 
             # Move master profiling logs into results so they get uploaded as artifacts
             mv results_master/memory_log_master_*.txt ./results/ 2>/dev/null || true
-            mv results_master/profile_*.csv ./results/profile_master_ecm_prep.csv 2>/dev/null || true
+            for step in "${steps[@]}"; do
+              mv results_master/profile_${step}.csv ./results/profile_master_${step}.csv 2>/dev/null || true
+            done
 
           else
             python tests/integration_testing/run_workflow.py --yaml tests/integration_testing/integration_test.yml

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -20,6 +20,7 @@ jobs:
       has_json_diff: ${{ steps.compare.outputs.has_json_diff }}
       has_plot_diff: ${{ steps.compare.outputs.has_plot_diff }}
       changed_plots: ${{ steps.compare.outputs.changed_plots }}
+      profile_comparison: ${{ steps.profile_comparison.outputs.profile_comparison }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,9 +72,21 @@ jobs:
             # --- Write comparison summary ---
             echo "=== Profiling Comparison ===" | tee results/profile_comparison.txt
             for step in "${steps[@]}"; do
+              echo "" | tee -a results/profile_comparison.txt
               echo "--- Step: $step ---" | tee -a results/profile_comparison.txt
-              echo "Master:  $(tail -1 results_master/profile_${step}.csv)" | tee -a results/profile_comparison.txt
-              echo "Feature: $(tail -1 results/profile_feature_${step}.csv)" | tee -a results/profile_comparison.txt
+
+              # Elapsed time = col 1 of the last data row of each psrecord memory log
+              m_time=$(grep -v "^#" "results/memory_log_master_${step}.txt" | grep -v "^$" | tail -n 1 | awk '{print $1}')
+              f_time=$(grep -v "^#" "results/memory_log_${step}.txt"        | grep -v "^$" | tail -n 1 | awk '{print $1}')
+
+              echo "Master  elapsed time: ${m_time}s" | tee -a results/profile_comparison.txt
+              echo "Feature elapsed time: ${f_time}s" | tee -a results/profile_comparison.txt
+
+              if [[ -n "$m_time" && -n "$f_time" ]]; then
+                abs_diff=$(awk "BEGIN {printf \"%.2f\", $m_time - $f_time}")
+                pct=$(awk "BEGIN {printf \"%.2f\", ($m_time - $f_time) / $m_time * 100}")
+                printf "Δ Time: %ss (%.2f%% improvement in feature vs master)\n" "$abs_diff" "$pct" | tee -a results/profile_comparison.txt
+              fi
             done
 
             # Move master profiling logs into results so they get uploaded as artifacts
@@ -88,6 +101,18 @@ jobs:
           rm -rf ./tests/integration_testing/results/*
           mv ./results/* ./tests/integration_testing/results/
           mv ./generated/log_*.txt ./tests/integration_testing/results/ 2>/dev/null
+      - name: Capture profiler comparison output
+        id: profile_comparison
+        run: |
+          if [[ -f "tests/integration_testing/results/profile_comparison.txt" ]]; then
+            content=$(cat tests/integration_testing/results/profile_comparison.txt)
+            echo "profile_comparison<<EOF" >> $GITHUB_OUTPUT
+            echo "$content" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "profile_comparison=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Compare integration test results
         id: compare
         run: |
@@ -319,6 +344,7 @@ jobs:
           HAS_JSON_DIFF: ${{ needs.run-test.outputs.has_json_diff }}
           HEAD_REF: ${{ github.head_ref }}
           CROSS_PLATFORM_RESULT: ${{ needs.cross-platform-test.result }}
+          PROFILE_COMPARISON: ${{ needs.run-test.outputs.profile_comparison }}
         with:
           script: |
             const fs = require('fs');
@@ -330,6 +356,7 @@ jobs:
             const hasPlotDiff = process.env.HAS_PLOT_DIFF;
             const headRef = process.env.HEAD_REF;
             const profilerEnabled = '${{ inputs.enable_profiler }}';
+            const profileComparison = process.env.PROFILE_COMPARISON || '';
             const crossPlatformResult = process.env.CROSS_PLATFORM_RESULT;
             const statusIcon = testResult === 'success' ? '✅' : (hasDiff === 'true' ? '⚠️' : '❌');
 
@@ -437,6 +464,35 @@ jobs:
                   body += `\n</details>\n\n`;
                 }
               }
+            }
+
+            // Embed profiler comparison if enabled
+            if (profilerEnabled === 'true' && profileComparison) {
+              body += `\n### ⏱️ Profiler Comparison (Feature vs Master)\n\n`;
+              body += `| Step | Master (s) | Feature (s) | Δ Time (s) | Improvement |\n`;
+              body += `|---|---|---|---|---|\n`;
+              // Parse lines like:
+              //   --- Step: ecm_prep ---
+              //   Master  elapsed time: 485.18s
+              //   Feature elapsed time: 460.00s
+              //   Δ Time: 25.18s (5.19% improvement in feature vs master)
+              const stepBlocks = profileComparison.split(/--- Step: (\w+) ---/).slice(1);
+              for (let i = 0; i < stepBlocks.length; i += 2) {
+                const stepName = stepBlocks[i].trim();
+                const block = stepBlocks[i + 1] || '';
+                const mMatch = block.match(/Master\s+elapsed time:\s+([\d.]+)s/);
+                const fMatch = block.match(/Feature\s+elapsed time:\s+([\d.]+)s/);
+                const dMatch = block.match(/Δ Time:\s+([-\d.]+)s\s+\(([-\d.]+)%/);
+                const mTime = mMatch ? mMatch[1] : 'N/A';
+                const fTime = fMatch ? fMatch[1] : 'N/A';
+                const absDiff = dMatch ? dMatch[1] : 'N/A';
+                const pct = dMatch ? dMatch[2] : 'N/A';
+                const icon = dMatch ? (parseFloat(dMatch[2]) >= 0 ? '✅' : '⚠️') : '';
+                body += `| \`${stepName}\` | ${mTime} | ${fTime} | ${absDiff} | ${icon} ${pct}% |\n`;
+              }
+              body += `\n<details><summary>Full profiler output</summary>\n\n`;
+              body += `\`\`\`\n${profileComparison}\n\`\`\`\n\n</details>\n\n`;
+              body += `_Full memory logs and cProfile CSVs are in the [workflow artifacts](${runUrl})._\n\n`;
             }
 
             await github.rest.issues.createComment({

--- a/test_profile.sh
+++ b/test_profile.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Local test script that mirrors the profiler logic in the CI workflow.
+# Runs ecm_prep and run steps for both the feature branch and master,
+# back-to-back on the same machine, then reports relative performance.
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+FEATURE_SHA=$(git rev-parse HEAD)
+mkdir -p results
+
+steps=("ecm_prep" "run")
+
+# --- Profile FEATURE branch ---
+echo "=== Profiling FEATURE branch ==="
+# Clear ecm_prep cache so each branch starts from a cold cache
+rm -rf generated/ecm_competition_data/*.pkl.gz
+rm -f  generated/ecm_prep.json
+
+for step in "${steps[@]}"; do
+  log_file="memory_log_feature_${step}.txt"
+
+  psrecord --log "$log_file" --include-children --interval 1 \
+    "python tests/integration_testing/run_workflow.py \
+      --run_step $step \
+      --yaml tests/integration_testing/integration_test.yml \
+      --with_profiler"
+
+  # run_workflow.py writes cProfile stats to results/profile_${step}.csv — rename with branch suffix
+  mv "results/profile_${step}.csv" "results/profile_${step}_feature.csv"
+
+  # Build a one-row summary CSV from the memory log (last data row = total elapsed time)
+  (
+    echo "# Elapsed time (s),CPU (%),Real (MB),Virtual (MB)"
+    grep -v "^#" "$log_file" | grep -v "^$" | tail -n 1 | awk '{printf "%.3f,%.3f,%.3f,%.3f\n",$1,$2,$3,$4}'
+  ) > "results/memory_summary_${step}_feature.csv"
+
+  mv "$log_file" "results/memory_log_${step}_feature.txt"
+done
+
+# --- Checkout master ---
+echo "=== Switching to master branch ==="
+git fetch --depth=1 origin master
+# Stash any tracked changes only (-u would stash the profiling results we just wrote)
+git stash --include-untracked=false -m "temp profiling stash" || true
+git checkout origin/master -- .
+pip install -c .github/constraints.txt ".[dev]" psrecord --quiet
+
+# --- Profile MASTER branch ---
+echo "=== Profiling MASTER branch ==="
+# Clear ecm_prep cache so master also starts from a cold cache
+rm -rf generated/ecm_competition_data/*.pkl.gz
+rm -f  generated/ecm_prep.json
+
+for step in "${steps[@]}"; do
+  log_file="memory_log_master_${step}.txt"
+
+  psrecord --log "$log_file" --include-children --interval 1 \
+    "python tests/integration_testing/run_workflow.py \
+      --run_step $step \
+      --yaml tests/integration_testing/integration_test.yml \
+      --with_profiler"
+
+  mv "results/profile_${step}.csv" "results/profile_${step}_master.csv"
+
+  (
+    echo "# Elapsed time (s),CPU (%),Real (MB),Virtual (MB)"
+    grep -v "^#" "$log_file" | grep -v "^$" | tail -n 1 | awk '{printf "%.3f,%.3f,%.3f,%.3f\n",$1,$2,$3,$4}'
+  ) > "results/memory_summary_${step}_master.csv"
+
+  mv "$log_file" "results/memory_log_${step}_master.txt"
+done
+
+# --- Restore feature branch ---
+echo "=== Restoring feature branch ==="
+git checkout "$FEATURE_SHA" -- .
+pip install -c .github/constraints.txt ".[dev]" psrecord --quiet
+git stash pop || true
+
+# --- Comparison ---
+echo ""
+echo "=== Profiling Comparison ===" | tee results/profile_comparison.txt
+
+for step in "${steps[@]}"; do
+  echo "" | tee -a results/profile_comparison.txt
+  echo "--- Step: $step ---" | tee -a results/profile_comparison.txt
+
+  # Extract elapsed time from the last data row of each memory log (col 1)
+  m_time=$(grep -v "^#" "results/memory_log_${step}_master.txt" | grep -v "^$" | tail -n 1 | awk '{print $1}')
+  f_time=$(grep -v "^#" "results/memory_log_${step}_feature.txt" | grep -v "^$" | tail -n 1 | awk '{print $1}')
+
+  echo "Master  elapsed time: ${m_time}s" | tee -a results/profile_comparison.txt
+  echo "Feature elapsed time: ${f_time}s" | tee -a results/profile_comparison.txt
+
+  if [[ -n "$m_time" && -n "$f_time" ]]; then
+    abs_diff=$(awk "BEGIN {printf \"%.2f\", $m_time - $f_time}")
+    pct=$(awk "BEGIN {printf \"%.2f\", ($m_time - $f_time) / $m_time * 100}")
+    printf "Δ Time: %ss (%.2f%% improvement in feature vs master)\n" "$abs_diff" "$pct" \
+      | tee -a results/profile_comparison.txt
+  fi
+done
+
+echo ""
+echo "Results saved in results/:"
+ls results/profile_*.csv results/memory_log_*.txt results/memory_summary_*.csv results/profile_comparison.txt 2>/dev/null


### PR DESCRIPTION
In cloud-based environments like GitHub Actions, CI runners are spun up on many virtual machines that share physical hardware with other users. This inevitably leads to the noisy neighbor problem, where the background load on the underlying host machine can drastically impact the wall-clock execution time of your job.

To accurately measure performance improvements, it's preferable to do relative profiling within a single environment. Within the exact same CI job, it checks out feature branch, do profiling, then checks out master branch, do profiling. This ensures both versions of the code are subjected to the exact same hardware specifications and very similar background loads.