### PR TITLE
remove OPT_INDENT_2 in orjson dump to improve memory

### DIFF
--- a/scout/utils.py
+++ b/scout/utils.py
@@ -57,7 +57,7 @@ class JsonIO:
             # stay consistent with the previous output format.
             raw = _orjson.dumps(
                 data,
-                option=_orjson.OPT_NON_STR_KEYS | _orjson.OPT_INDENT_2,
+                option=_orjson.OPT_NON_STR_KEYS,
                 default=_orjson_default,
             )
             Path(filepath).write_bytes(raw)


### PR DESCRIPTION
so output is now compact instead of pretty-printed. Smaller files on disk, less CPU/memory spent formatting on write, and less to buffer when something reads it back.
This helps resolving CI memory strain running expanded CI test suite