### PR TITLE
Add BTB data pipeline for populating meas_in cost/performance data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,9 @@ scout.egg-info/
 
 scout/supporting_data/base_disagg/input
 scout/supporting_data/base_disagg/output
+
+# BTB data #
+######################
+
+scout/supporting_data/btb/raw
+scout/supporting_data/btb/bss_meas_v2_btb_proposed.xlsx

--- a/scout/supporting_data/btb/README.md
+++ b/scout/supporting_data/btb/README.md
@@ -1,0 +1,119 @@
+# Populating cost/performance/lifetime data from BTB
+
+`bss_meas_v2.xlsx` (sheet `meas_in`) is the curated spreadsheet that feeds
+`meas_pkg_gen.py` (repo root) to generate Scout measure JSONs. Many rows
+cite "Buildings Annual Technology Baseline. NREL, forthcoming" as the
+source for their Energy Performance / Installed Cost / Lifetime values --
+that dataset has since been published on OpenEI as the **2024 Buildings
+Technology Baseline (BTB)** (https://data.openei.org/submissions/8342).
+The three scripts here pull directly from the published BTB CSVs instead
+of hand-transcribing values from a Google Sheet.
+
+**Scope:** only technologies BTB explicitly covers with clear cost/
+performance data -- HVAC, Water Heating, Lighting, Refrigeration, and
+Cooking, both residential and commercial. Envelope (windows, walls,
+infiltration) and electronics/MELs (laptops, TVs, smart speakers, etc.)
+have no BTB coverage and are not touched by this workflow.
+
+**Nothing here ever overwrites `bss_meas_v2.xlsx` directly.** The pipeline
+ends in a separate reviewable file with a diff sheet, so a human can
+sanity-check every proposed change before merging any of it back into the
+curated original by hand.
+
+## 1. Download the BTB data
+
+```
+cd scout/supporting_data/btb
+python download_btb_data.py
+```
+
+Downloads the residential and commercial CSVs (from OpenEI submission
+8342) to `raw/btb_residential.csv` and `raw/btb_commercial.csv`. That
+directory is git-ignored (large, re-downloadable). Pass `--overwrite` to
+re-download; otherwise existing files are left alone.
+
+## 2. Build (and review) the technology crosswalk
+
+```
+python build_tech_crosswalk.py
+```
+
+Matches every Scout technology token used in `meas_in`'s `Baseline
+Technology`/`Switched to Technology` columns against BTB's Display
+Name/Component/Technology-Measure/Fuel Type text, using the rule table in
+`MATCH_RULES` at the top of the script. Writes/updates `tech_crosswalk.csv`
+(checked into git -- this is meant to be hand-curated over time, not
+regenerated from scratch each run).
+
+Each matched technology is expanded into the 4 `meas_in` efficiency tiers
+(Ref. Case, Min. Efficiency, ESTAR, Best) using a default mapping to BTB's
+Projection Scenario/year/bound (see `TIER_DEFAULTS`) -- **this default is
+a starting point for review, not a validated result.** In particular:
+
+- All 4 tiers currently draw from the *same* matched BTB Technology ID,
+  varying only scenario/bound/year. Where BTB has a genuinely distinct
+  higher-efficiency product (e.g. a condensing vs. non-condensing gas
+  boiler), this script does not auto-detect and switch technology --
+  those cases surface as `needs_review` (ambiguous, multiple candidates)
+  instead, or may need a manual crosswalk row pointing a specific tier at
+  a different Technology ID.
+- Every row defaults to BTB's 2023 projection year regardless of tier.
+  Adjust `projection_year` by hand in the CSV if a later-vintage
+  projection is more appropriate for a given tier (e.g. ESTAR/Best).
+
+**Only 48 of the ~100 Scout technology tokens used in `meas_in` have an
+authored rule** (see `MATCH_RULES`); the rest print a warning and are left
+out of the crosswalk entirely. Add a rule to cover more.
+
+Rows come out flagged `needs_review = True` (and no BTB id filled in) when:
+- No BTB row matched the rule (`match_confidence = none`), or
+- More than one BTB row matched (`match_confidence = ambiguous` -- the
+  `notes` column lists every candidate found).
+
+Re-running this script only *adds* missing `(technology, tier)` rows --
+existing rows (including ones you've hand-corrected) are left alone. Pass
+`--refresh` to recompute everything from scratch (discards manual edits).
+
+## 3. Propose values and review the diff
+
+```
+python populate_meas_in_from_btb.py
+```
+
+For every `meas_in` row and every technology in it that has a
+non-`needs_review` crosswalk entry matching that row's inferred tier
+(parsed from the `Name` column), this looks up the matching BTB row
+(technology + projection year + scenario) and computes what the Energy
+Performance / Installed Cost / Lifetime values would be, converting units
+where needed (see `unit_conversions.py` -- anything without a known
+conversion rule is silently skipped here, not guessed at).
+
+Writes `bss_meas_v2_btb_proposed.xlsx` (git-ignored, not meant to be
+committed) containing:
+- A copy of `meas_in` with proposed values substituted in for just the
+  resolved technology/column combinations -- everything else in a shared
+  cell (other technologies, formatting, unrelated columns) is left
+  byte-for-byte as it was.
+- A `BTB Diff` sheet: one row per changed cell, with the old value, the
+  proposed new value, and the matched BTB technology/scenario/year, so
+  you can judge each change before copying it into the real file.
+
+**Known gotcha:** a cost of exactly `$0` for a technology in the original
+sheet usually means its cost was deliberately zeroed out because it
+shares physical equipment with a paired heating/cooling technology in the
+same row (e.g. a heat pump's cost entered once under "heat" and zeroed
+under "cool" to avoid double-counting). The script recognizes this pattern
+and leaves those cells alone (logged in the diff as `(skipped)` with a
+note) rather than reintroducing a double-count -- but double-check any
+row where this fires, since it's a heuristic, not a certainty.
+
+## After reviewing
+
+There is currently no automated "apply" step -- copy whichever proposed
+values you accept from `bss_meas_v2_btb_proposed.xlsx` into
+`bss_meas_v2.xlsx` by hand (and update the corresponding Source
+Notes/Details columns to cite BTB, e.g. title "2024 Buildings Technology
+Baseline", author Guidehouse/NREL, year 2024/2025, url
+https://data.openei.org/submissions/8342), then re-export the `meas_in`
+sheet to `ecm_definitions/meas_pkg_gen_io/inputs/meas_in.csv` for
+`meas_pkg_gen.py` to pick up.

--- a/scout/supporting_data/btb/build_tech_crosswalk.py
+++ b/scout/supporting_data/btb/build_tech_crosswalk.py
@@ -1,0 +1,359 @@
+"""Build/update tech_crosswalk.csv, linking Scout technology tokens to BTB rows.
+
+`meas_in` (the "meas_in" sheet of bss_meas_v2.xlsx) refers to technologies
+using Scout's short internal tokens (e.g. "ASHP", "central AC", "furnace
+(NG)", "boiler (NG)"). The BTB CSVs (./raw/btb_residential.csv,
+./raw/btb_commercial.csv) identify technologies by a "Display Name" plus
+Component/Technology-Measure/Fuel Type columns, and only sometimes fill in
+a "Mapping to Most Granular EIA/Scout Tech/Measure Name" column -- that
+column is informative when present but is blank for some technologies that
+are otherwise clearly identifiable (e.g. "Furnace Gas-fired" has no mapping
+entry at all), so matching here is keyword-based against the descriptive
+columns rather than a hard requirement on that column.
+
+This script is meant to be re-run as BTB data updates, but should not
+clobber human edits: any (scout_technology, sector) pair already present in
+tech_crosswalk.csv is left untouched unless --refresh is passed.
+
+Each matched Scout technology is expanded into 4 rows, one per meas_in
+efficiency tier (Ref. Case, Min. Efficiency, ESTAR, Best), using a default
+mapping from tier to BTB "Projection Scenario" + regression/cost "bound"
+that the user asked to have proposed here for review rather than trusted
+outright -- see TIER_DEFAULTS below and the README. In particular, note
+that tiers here always draw from the *same* matched BTB Technology ID,
+varying only scenario/bound/year; where BTB has a genuinely distinct
+higher-efficiency product class (e.g. condensing vs. non-condensing gas
+boilers), this script does not attempt to auto-detect and switch to it --
+such cases surface naturally as ambiguous (multiple candidates) matches
+that need manual resolution, or should be redirected manually in the CSV.
+
+Usage (from this directory):
+    python build_tech_crosswalk.py
+    python build_tech_crosswalk.py --refresh   # recompute all rows
+"""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+BASE_DIR = Path(__file__).resolve().parent
+RAW_DIR = BASE_DIR / "raw"
+XLSX_PATH = BASE_DIR / "bss_meas_v2.xlsx"
+CROSSWALK_PATH = BASE_DIR / "tech_crosswalk.csv"
+
+# meas_in efficiency tier -> default BTB Projection Scenario/year/bound.
+# "bound" uses a canonical Low/Typical/High vocabulary; translated to BTB's
+# actual column-naming (regression metrics use Lower Bound/Typical/Upper
+# Bound, costs use Low/Mid/High) in populate_meas_in_from_btb.py.
+TIER_DEFAULTS = {
+    "Ref. Case": {"scenario": "Reference", "year": 2023, "bound": "Typical"},
+    "Min. Efficiency": {"scenario": "Reference", "year": 2023, "bound": "Low"},
+    "ESTAR": {"scenario": "Advanced", "year": 2023, "bound": "Typical"},
+    "Best": {"scenario": "Advanced", "year": 2023, "bound": "High"},
+}
+
+# Whichever meas_in unit label (COP, AFUE, BTU out/BTU in, UEF, ...) a given
+# row actually uses for a matched technology is only known once
+# populate_meas_in_from_btb.py looks at that specific row -- so this script
+# just records which BTB regression metric would supply the performance
+# value, and leaves the convertibility check (see unit_conversions.py) to
+# the populate step.
+CROSSWALK_COLUMNS = [
+    "scout_technology", "sector", "tier", "btb_technology_id",
+    "btb_display_name", "btb_mapping_name", "btb_metric_name",
+    "projection_scenario", "projection_year", "bound", "match_confidence",
+    "needs_review", "notes",
+]
+
+# Rule table: scout_technology -> matching rule(s). Each rule is matched
+# against a lowercased concatenation of Display Name / Component /
+# Technology-Measure / Fuel Type text in the named sector's BTB CSV.
+# "include" keywords must ALL appear; "exclude" keywords must NONE appear.
+# Only technologies with a clear, defensible rule are listed here -- every
+# other Scout technology used in meas_in falls through to a needs_review
+# row with no BTB match, rather than being guessed at.
+MATCH_RULES = {
+    # -- Residential HVAC --
+    "ASHP": [("residential", ["air source heat pump"], ["new circuit"])],
+    "GSHP": [("residential", ["ground source heat pump"], [])],
+    "boiler (distillate)": [("residential", ["boiler", "oil"], ["gas"])],
+    "furnace (NG)": [
+        ("residential", ["furnace", "gas"], ["air conditioner"])],
+    "furnace (distillate)": [("residential", ["furnace", "oil"], [])],
+    "central AC": [
+        ("residential", ["central air conditioner"], ["furnace"])],
+    "room AC": [("residential", ["room air conditioner"], ["connected"])],
+    "resistance heat": [
+        ("residential", ["furnace", "electric resistance"], [])],
+    # -- Residential Water Heating --
+    "HPWH": [
+        ("residential", ["water heater", "hp tank"],
+         ["new circuit", "240v"])],
+    "elec_water_heater": [
+        ("residential", ["water heater", "electric instantaneous"], [])],
+    # -- Residential Lighting --
+    "general service (LED)": [("residential", ["led a19"], [])],
+    # -- Residential Appliances --
+    "dishwasher": [("residential", ["dishwasher"], ["connected"])],
+    "electric dryer": [
+        ("residential", ["clothes dryer", "electric"],
+         ["compact", "connected", "gas", "heat pump"])],
+    # -- Residential Cooking --
+    "electric range": [
+        ("residential", ["cooking range", "electric"], ["induction"])],
+    "induction": [("residential", ["cooking range", "induction"], [])],
+
+    # -- Commercial HVAC --
+    "rooftop_ASHP-cool": [("commercial", ["rtu heat pump", "standard"], [])],
+    "rooftop_ASHP-heat": [("commercial", ["rtu heat pump", "standard"], [])],
+    "rooftop_AC": [
+        ("commercial", ["electric rooftop unit"], ["heat pump", "gas heat"])],
+    "res_type_central_AC": [
+        ("residential", ["central air conditioner"], ["furnace"])],
+    "comm_GSHP-cool": [
+        ("commercial", ["ground source heat pump"], [])],
+    "comm_GSHP-heat": [
+        ("commercial", ["ground source heat pump"], [])],
+    "centrifugal_chiller": [
+        ("commercial", ["centrifugal chiller", "water-cooled"], [])],
+    "scroll_chiller": [
+        ("commercial", ["scroll chiller", "air-cooled"], [])],
+    "screw_chiller": [
+        ("commercial", ["screw chiller", "air-cooled"], [])],
+    "reciprocating_chiller": [
+        ("commercial", ["reciprocating chiller", "air-cooled"], [])],
+    "gas_chiller": [
+        ("commercial", ["gas-fired chillers", "water cooled"], [])],
+    "gas_eng-driven_RTAC": [
+        ("commercial", ["gas-fired engine-drive"], [])],
+    "pkg_terminal_AC-cool": [
+        ("commercial", ["packaged terminal air conditioner"], [])],
+    "pkg_terminal_HP-cool": [
+        ("commercial", ["heat pump", "packaged terminal"], [])],
+    "pkg_terminal_HP-heat": [
+        ("commercial", ["heat pump", "packaged terminal"], [])],
+    "gas_boiler": [("commercial", ["boiler", "gas-fired"], [])],
+    # BTB has separate "Electric Steam" and "Electric Hot Water" commercial
+    # boiler entries; hot water is picked as the more common distribution
+    # type -- review and repoint to the steam variant if a given measure
+    # specifically concerns steam heating.
+    "elec_boiler": [("commercial", ["boiler", "electric"], ["steam"])],
+    "oil_boiler": [("commercial", ["boiler", "oil-fired"], [])],
+    "gas_furnace": [("commercial", ["furnace", "gas-fired"], [])],
+    "oil_furnace": [("commercial", ["furnace", "oil-fired"], [])],
+    "elec_res-heater": [
+        ("commercial", ["unit heater", "electric"], [])],
+    "VAV_Vent": [
+        ("commercial", ["variable air volume system"], [])],
+    "CAV_Vent": [
+        ("commercial", ["constant air volume system"], [])],
+    # -- Commercial Water Heating --
+    "elec_range-combined": [
+        ("commercial", ["electric range", "griddle"], [])],
+
+    # -- Commercial Lighting --
+    "LED": [("commercial", ["led troffer", "panel"], ["dimming", "control"])],
+
+    # -- Commercial Refrigeration --
+    "Commercial Ice Machines": [
+        ("commercial", ["ice machine", "standard"], [])],
+    "Commercial Beverage Merchandisers": [
+        ("commercial", ["beverage merchandisers", "standard"], [])],
+    "Commercial Refrigerated Vending Machines": [
+        ("commercial", ["refrigerated vending machine", "standard"], [])],
+    "Commercial Reach-In Freezers": [
+        ("commercial", ["reach-in freezer"], [])],
+    "Commercial Reach-In Refrigerators": [
+        ("commercial", ["reach-in refrigerator"], [])],
+    "Commercial Walk-In Freezers": [
+        ("commercial", ["walk-in", "freezer"], [])],
+    "Commercial Walk-In Refrigerators": [
+        ("commercial", ["walk-in", "cooler"], [])],
+    "Commercial Supermarket Display Cases": [
+        ("commercial", ["supermarket display cases"], [])],
+}
+
+
+def load_btb(sector):
+    """Load a BTB CSV and return it with a normalized 'search_text' column.
+
+    Args:
+        sector (str): "residential" or "commercial".
+
+    Returns:
+        DataFrame with an added lowercased 'search_text' column and a
+        normalized 'tech_id' column (BTB uses different ID column names
+        for the two sectors).
+    """
+
+    fname = "btb_residential.csv" if sector == "residential" \
+        else "btb_commercial.csv"
+    path = RAW_DIR / fname
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{path} not found -- run download_btb_data.py first.")
+    df = pd.read_csv(path, low_memory=False)
+    id_col = "Technology ID" if "Technology ID" in df.columns \
+        else "Technology/Measure ID"
+    df = df.rename(columns={id_col: "tech_id"})
+    text_cols = ["Display Name", "Component", "Technology/Measure",
+                 "Fuel Type"]
+    df["search_text"] = df[text_cols].astype(str).agg(" | ".join, axis=1) \
+        .str.lower()
+    return df
+
+
+def find_candidates(df, include_kw, exclude_kw):
+    """Return distinct BTB tech_ids whose search_text matches a rule."""
+
+    mask = df["search_text"].apply(
+        lambda t: all(kw in t for kw in include_kw)
+        and not any(kw in t for kw in exclude_kw))
+    matched = df[mask].dropna(subset=["tech_id"])
+    return matched.drop_duplicates(subset=["tech_id"])
+
+
+def scout_technologies_in_use(xlsx_path):
+    """Collect every distinct technology token referenced in meas_in."""
+
+    df = pd.read_excel(xlsx_path, sheet_name="meas_in")
+    techs = set()
+    for col in ["Baseline Technology", "Switched to Technology"]:
+        for val in df[col].dropna():
+            for part in str(val).split(";"):
+                part = part.strip()
+                if part:
+                    techs.add(part)
+    return techs
+
+
+def performance_metric_for_row(row):
+    """Pick whichever of a BTB row's two regression metrics is an
+    efficiency-type metric convertible to Scout units (see
+    unit_conversions.py), preferring metric 2 (where such metrics were
+    observed to live in the source data)."""
+
+    for i in (2, 1):
+        metric_name = row.get(f"Regression metric {i} - Metric")
+        if pd.notna(metric_name):
+            return i, metric_name
+    return None, None
+
+
+def build_rows_for_technology(scout_tech, rules):
+    """Match one Scout technology token against BTB data and expand across
+    all four meas_in efficiency tiers.
+
+    Returns a list of crosswalk row dicts.
+    """
+
+    all_candidates = []
+    for sector, include_kw, exclude_kw in rules:
+        df = load_btb(sector)
+        cands = find_candidates(df, include_kw, exclude_kw)
+        for _, cand in cands.iterrows():
+            all_candidates.append((sector, cand))
+
+    rows = []
+    if len(all_candidates) == 0:
+        for tier in TIER_DEFAULTS:
+            rows.append({
+                "scout_technology": scout_tech, "sector": "",
+                "tier": tier, "btb_technology_id": "",
+                "btb_display_name": "", "btb_mapping_name": "",
+                "btb_metric_name": "",
+                "projection_scenario": "", "projection_year": "",
+                "bound": "", "match_confidence": "none",
+                "needs_review": True,
+                "notes": "no BTB row matched the authored search rule(s)",
+            })
+        return rows
+
+    if len(all_candidates) > 1:
+        cand_desc = "; ".join(
+            f"{sector}#{cand['tech_id']}:{cand['Display Name']}"
+            for sector, cand in all_candidates)
+        for tier in TIER_DEFAULTS:
+            rows.append({
+                "scout_technology": scout_tech, "sector": "",
+                "tier": tier, "btb_technology_id": "",
+                "btb_display_name": "", "btb_mapping_name": "",
+                "btb_metric_name": "",
+                "projection_scenario": "", "projection_year": "",
+                "bound": "", "match_confidence": "ambiguous",
+                "needs_review": True,
+                "notes": f"{len(all_candidates)} candidate BTB rows matched: "
+                         f"{cand_desc}",
+            })
+        return rows
+
+    sector, cand = all_candidates[0]
+    metric_idx, metric_name = performance_metric_for_row(cand)
+    needs_review = metric_name is None
+    notes = "" if metric_name is not None else (
+        "BTB row has no identified performance metric")
+    for tier, defaults in TIER_DEFAULTS.items():
+        rows.append({
+            "scout_technology": scout_tech, "sector": sector,
+            "tier": tier, "btb_technology_id": cand["tech_id"],
+            "btb_display_name": cand["Display Name"],
+            "btb_metric_name": metric_name or "",
+            "btb_mapping_name": cand.get(
+                "Mapping to Most Granular EIA/Scout Tech/Measure Name", ""),
+            "projection_scenario": defaults["scenario"],
+            "projection_year": defaults["year"], "bound": defaults["bound"],
+            "match_confidence": "high", "needs_review": needs_review,
+            "notes": notes,
+        })
+    return rows
+
+
+def main(refresh):
+    """Build (or incrementally update) tech_crosswalk.csv."""
+
+    existing = None
+    if CROSSWALK_PATH.exists() and not refresh:
+        existing = pd.read_csv(CROSSWALK_PATH)
+        already_covered = set(
+            zip(existing["scout_technology"], existing["tier"]))
+    else:
+        already_covered = set()
+
+    techs = sorted(scout_technologies_in_use(XLSX_PATH) & set(MATCH_RULES))
+    skipped = sorted(scout_technologies_in_use(XLSX_PATH) - set(MATCH_RULES))
+    print(f"{len(techs)} technologies have an authored match rule; "
+          f"{len(skipped)} technologies have no rule yet and are skipped "
+          "(add a rule to MATCH_RULES to cover them).")
+
+    new_rows = []
+    for scout_tech in techs:
+        rules = MATCH_RULES[scout_tech]
+        rows = build_rows_for_technology(scout_tech, rules)
+        for row in rows:
+            if (row["scout_technology"], row["tier"]) not in already_covered:
+                new_rows.append(row)
+
+    if existing is not None:
+        out = pd.concat(
+            [existing, pd.DataFrame(new_rows, columns=CROSSWALK_COLUMNS)],
+            ignore_index=True)
+    else:
+        out = pd.DataFrame(new_rows, columns=CROSSWALK_COLUMNS)
+
+    out = out.sort_values(["scout_technology", "tier"]).reset_index(drop=True)
+    out.to_csv(CROSSWALK_PATH, index=False)
+    n_review = int(out["needs_review"].astype(bool).sum())
+    print(f"Wrote {len(out)} rows to {CROSSWALK_PATH} "
+          f"({n_review} flagged needs_review).")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Build/update the Scout-technology <-> BTB crosswalk.")
+    parser.add_argument(
+        "--refresh", action="store_true",
+        help="Recompute every row instead of only adding missing ones "
+             "(overwrites any manual edits).")
+    args = parser.parse_args()
+    main(args.refresh)

--- a/scout/supporting_data/btb/download_btb_data.py
+++ b/scout/supporting_data/btb/download_btb_data.py
@@ -1,0 +1,87 @@
+"""Download the NREL Buildings Technology Baseline (BTB) dataset from OpenEI.
+
+BTB (https://data.openei.org/submissions/8342) is a public NREL/Guidehouse
+dataset of current and projected cost, performance, and lifetime data for
+residential and commercial building energy technologies. It is the intended
+source for the Energy Performance / Installed Cost / Lifetime columns in
+./bss_meas_v2.xlsx (sheet "meas_in") that currently cite "Buildings Annual
+Technology Baseline. NREL, forthcoming" but were transcribed by hand.
+
+This script just downloads the two flat CSV files (residential and
+commercial) into ./raw/, which is git-ignored since the files are large and
+re-downloadable. Run this before build_tech_crosswalk.py or
+populate_meas_in_from_btb.py.
+
+No API key required -- OpenEI serves these as public direct file links.
+
+Usage (from this directory, or any cwd -- paths are relative to this file):
+    python download_btb_data.py
+    python download_btb_data.py --overwrite
+"""
+
+import argparse
+from pathlib import Path
+
+import requests
+
+BASE_DIR = Path(__file__).resolve().parent
+OUT_DIR = BASE_DIR / "raw"
+
+# Direct file links taken from the OpenEI submission page (id 8342).
+SOURCES = {
+    "residential": {
+        "url": (
+            "https://data.openei.org/files/8342/"
+            "btb2024_residential_dataset%20(3).csv"
+        ),
+        "filename": "btb_residential.csv",
+    },
+    "commercial": {
+        "url": (
+            "https://data.openei.org/files/8342/"
+            "btb2024_commercial_dataset%20(4).csv"
+        ),
+        "filename": "btb_commercial.csv",
+    },
+}
+
+
+def download_file(url, out_path, overwrite):
+    """Download a single BTB CSV file if it is not already present.
+
+    Args:
+        url (str): Direct download URL for the file.
+        out_path (Path): Local destination path.
+        overwrite (bool): Re-download and replace an existing file.
+    """
+
+    if out_path.exists() and not overwrite:
+        print(f"  {out_path.name} already exists, skipping "
+              "(use --overwrite to re-download).")
+        return
+
+    print(f"  Downloading {out_path.name}...", end="", flush=True)
+    resp = requests.get(url, timeout=(5, 60))
+    resp.raise_for_status()
+    out_path.write_bytes(resp.content)
+    print(f" done ({len(resp.content) / 1e6:.2f} MB).")
+
+
+def main(overwrite):
+    """Download all BTB source CSVs into ./raw/."""
+
+    OUT_DIR.mkdir(exist_ok=True)
+    print(f"Writing BTB CSVs to {OUT_DIR}")
+    for sector, cfg in SOURCES.items():
+        print(f"Sector: {sector}")
+        download_file(cfg["url"], OUT_DIR / cfg["filename"], overwrite)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Download BTB residential/commercial CSVs from OpenEI.")
+    parser.add_argument(
+        "-o", "--overwrite", action="store_true",
+        help="Re-download files even if they already exist in ./raw/.")
+    args = parser.parse_args()
+    main(args.overwrite)

--- a/scout/supporting_data/btb/populate_meas_in_from_btb.py
+++ b/scout/supporting_data/btb/populate_meas_in_from_btb.py
@@ -1,0 +1,439 @@
+"""Propose BTB-derived cost/performance/lifetime values for meas_in.
+
+Reads bss_meas_v2.xlsx (sheet "meas_in"), tech_crosswalk.csv (see
+build_tech_crosswalk.py), and the raw BTB CSVs, and for every (measure row,
+technology) pair covered by a non-`needs_review` crosswalk entry, computes
+what the Energy Performance / Installed Cost / Lifetime cells for that
+technology *would* be if sourced from BTB.
+
+This never modifies bss_meas_v2.xlsx. It writes bss_meas_v2_btb_proposed.xlsx
+alongside it: a copy of meas_in with proposed values substituted in (only
+for the specific technology substrings that were resolved -- everything
+else in a shared cell, e.g. other technologies not covered by the
+crosswalk, is left byte-for-byte as-is), plus a "BTB Diff" sheet listing
+every change with its old/new value and matched BTB source, for manual
+review before merging anything back into the curated original.
+
+Usage (from this directory):
+    python populate_meas_in_from_btb.py
+"""
+
+import re
+from pathlib import Path
+
+import openpyxl
+import pandas as pd
+
+from unit_conversions import convert
+
+BASE_DIR = Path(__file__).resolve().parent
+RAW_DIR = BASE_DIR / "raw"
+XLSX_PATH = BASE_DIR / "bss_meas_v2.xlsx"
+CROSSWALK_PATH = BASE_DIR / "tech_crosswalk.csv"
+OUT_PATH = BASE_DIR / "bss_meas_v2_btb_proposed.xlsx"
+
+SHEET_NAME = "meas_in"
+
+TIER_KEYWORDS = [
+    # Longer/more specific strings first so e.g. "ESTAR" doesn't also match
+    # a "Min. Efficiency ESTAR ..." style name meant for a different tier.
+    ("Min. Efficiency", "Min. Efficiency"),
+    ("ESTAR", "ESTAR"),
+    ("Best", "Best"),
+    ("Ref. Case", "Ref. Case"),
+]
+
+# canonical bound -> BTB regression-metric bound column suffix
+REGRESSION_BOUND_COL = {
+    "Low": "Lower Bound", "Typical": "Typical", "High": "Upper Bound"}
+# canonical bound -> BTB installed-cost column suffix
+COST_BOUND_COL = {"Low": "Low", "Typical": "Mid", "High": "High"}
+
+# Technologies covered by build_tech_crosswalk.py that participate in a
+# shared "heating"/"cooling"/"ventilation" Performance Units key rather
+# than their own tech-name key (seen in combined-package meas_in rows,
+# e.g. "(C) Ref. Case NG Boiler & Chiller"). Used only as a fallback when a
+# row's Performance Units cell has no key matching the technology name
+# directly.
+END_USE_FALLBACK = {
+    "heating": [
+        "gas_boiler", "elec_boiler", "oil_boiler", "gas_furnace",
+        "oil_furnace", "elec_res-heater", "rooftop_ASHP-heat",
+        "comm_GSHP-heat", "pkg_terminal_HP-heat", "resistance heat",
+        "furnace (NG)", "furnace (distillate)", "boiler (distillate)",
+        "ASHP", "GSHP", "HPWH"],
+    "cooling": [
+        "gas_chiller", "centrifugal_chiller", "scroll_chiller",
+        "screw_chiller", "reciprocating_chiller", "rooftop_AC",
+        "rooftop_ASHP-cool", "comm_GSHP-cool", "pkg_terminal_AC-cool",
+        "pkg_terminal_HP-cool", "gas_eng-driven_RTAC", "central AC",
+        "room AC", "ASHP", "GSHP"],
+    "ventilation": ["VAV_Vent", "CAV_Vent"],
+}
+
+
+def normalize_btb(df, sector):
+    """Rename sector-specific columns to a common schema."""
+
+    id_col = "Technology ID" if "Technology ID" in df.columns \
+        else "Technology/Measure ID"
+    rename = {id_col: "tech_id"}
+    if sector == "commercial":
+        rename.update({
+            "Year": "Projection Year", "Scenario": "Projection Scenario"})
+    return df.rename(columns=rename)
+
+
+def load_btb_data():
+    """Load and normalize both BTB CSVs, keyed by sector name."""
+
+    out = {}
+    for sector, fname in [
+            ("residential", "btb_residential.csv"),
+            ("commercial", "btb_commercial.csv")]:
+        path = RAW_DIR / fname
+        if not path.exists():
+            raise FileNotFoundError(
+                f"{path} not found -- run download_btb_data.py first.")
+        out[sector] = normalize_btb(
+            pd.read_csv(path, low_memory=False), sector)
+    return out
+
+
+def tier_for_name(name):
+    """Infer a meas_in efficiency tier from a measure's Name string."""
+
+    if not isinstance(name, str):
+        return None
+    for keyword, tier in TIER_KEYWORDS:
+        if keyword in name:
+            return tier
+    return None
+
+
+def techs_for_row(row):
+    """Ordered, de-duplicated technology tokens referenced by a meas_in row."""
+
+    seen = []
+    for col in ["Baseline Technology", "Switched to Technology"]:
+        val = row.get(col)
+        if isinstance(val, str):
+            for part in val.split(";"):
+                part = part.strip()
+                if part and part not in seen:
+                    seen.append(part)
+    return seen
+
+
+def find_value_for_key(cell, key):
+    """Return the raw (unparsed) value substring for `key` in a nested
+    "key: value; key2: value2" cell, or the whole cell if it has no nested
+    keys at all, or None if `key` is not present in a nested cell."""
+
+    if not isinstance(cell, str):
+        return None
+    if ":" not in cell:
+        return cell.strip()
+    pattern = re.compile(
+        re.escape(key) + r"\s*:\s*([^;]+)", re.IGNORECASE)
+    match = pattern.search(cell)
+    return match.group(1).strip() if match else None
+
+
+def unit_for_tech(perf_units_cell, tech):
+    """Resolve the meas_in performance unit that applies to `tech` in a
+    given row, trying a direct tech-name key first and falling back to the
+    row's heating/cooling/ventilation end-use key (see END_USE_FALLBACK)."""
+
+    direct = find_value_for_key(perf_units_cell, tech)
+    if direct:
+        return direct
+    if isinstance(perf_units_cell, str):
+        for end_use, techs in END_USE_FALLBACK.items():
+            if tech in techs:
+                via_end_use = find_value_for_key(perf_units_cell, end_use)
+                if via_end_use:
+                    return via_end_use
+    return None
+
+
+def replace_value_for_key(cell, key, new_value):
+    """Substitute the value for `key` in a nested cell (or replace the
+    whole cell if it has no nested keys), leaving all other keys/formatting
+    untouched. Returns the original cell unchanged if `key` is not found in
+    a nested cell (caller should not have called this in that case)."""
+
+    if not isinstance(cell, str):
+        return cell
+    if ":" not in cell:
+        return new_value
+    pattern = re.compile(
+        r"(" + re.escape(key) + r"\s*:\s*)([^;]+)", re.IGNORECASE)
+    return pattern.sub(lambda m: m.group(1) + new_value, cell, count=1)
+
+
+def replace_cost_for_key(cell, key, new_cost):
+    """Same as replace_value_for_key, but for the "key: new: X; key:
+    existing: Y" nesting used by the Installed Cost column."""
+
+    if not isinstance(cell, str):
+        return cell
+    if ":" not in cell:
+        # No existing nested cost structure to preserve -- write a fresh
+        # "new: X; existing: Y" pair for this (single) technology.
+        return f"new: {new_cost['new']}; existing: {new_cost['existing']}"
+    result = cell
+    any_found = False
+    for sub_key, val in new_cost.items():
+        pattern = re.compile(
+            r"(" + re.escape(key) + r"\s*:\s*" + re.escape(sub_key) +
+            r"\s*:\s*)([^;]+)", re.IGNORECASE)
+        if pattern.search(result):
+            any_found = True
+            result = pattern.sub(
+                lambda m: m.group(1) + str(val), result, count=1)
+    return result if any_found else cell
+
+
+def get_btb_row(btb_data, entry):
+    """Look up the single BTB row matching a crosswalk entry's technology
+    ID, projection year, and projection scenario."""
+
+    df = btb_data[entry["sector"]]
+    match = df[
+        (df["tech_id"] == entry["btb_technology_id"])
+        & (df["Projection Year"] == entry["projection_year"])
+        & (df["Projection Scenario"] == entry["projection_scenario"])]
+    if len(match) != 1:
+        return None
+    return match.iloc[0]
+
+
+def parse_currency(val):
+    """Parse a BTB cost value (e.g. "$5,158" or 5158.0) into a float."""
+
+    if pd.isna(val):
+        return None
+    if isinstance(val, str):
+        val = val.replace("$", "").replace(",", "").strip()
+        if not val:
+            return None
+    try:
+        return float(val)
+    except ValueError:
+        return None
+
+
+def is_zero_cost_placeholder(old_cost):
+    """True if a technology's existing cost has a "new" or "existing"
+    sub-value of exactly 0. A real installed cost is never $0, so this
+    normally means the cost was deliberately zeroed out because the
+    technology shares physical equipment with a paired heating/cooling
+    technology elsewhere in the same row (e.g. a heat pump's cost entered
+    once under the "heat" entry and zeroed under "cool" to avoid double-
+    counting total installed cost) -- such rows are left alone rather than
+    overwritten with a full BTB cost that would reintroduce that
+    double-count.
+    """
+
+    if not isinstance(old_cost, str):
+        return False
+    for part in old_cost.split(";"):
+        if ":" in part:
+            val = parse_currency(part.split(":", 1)[1])
+            if val == 0:
+                return True
+    return False
+
+
+def compute_cost(btb_row, bound):
+    """Return {"new": ..., "existing": ...} installed cost for a bound."""
+
+    suffix = COST_BOUND_COL[bound]
+    new_col = f"Typical New Construction Installed Cost ($2023) - {suffix}"
+    existing_col = f"Typical Retrofit Installed Cost ($2023) - {suffix}"
+    new_val = parse_currency(btb_row.get(new_col))
+    existing_val = parse_currency(btb_row.get(existing_col))
+    if new_val is None or existing_val is None:
+        return None
+    return {"new": round(new_val, 2), "existing": round(existing_val, 2)}
+
+
+def main():
+    """Build the BTB-proposed workbook and diff sheet."""
+
+    btb_data = load_btb_data()
+    crosswalk = pd.read_csv(CROSSWALK_PATH)
+    crosswalk = crosswalk[~crosswalk["needs_review"].astype(bool)]
+    crosswalk_by_tech_tier = {
+        (row["scout_technology"], row["tier"]): row
+        for _, row in crosswalk.iterrows()}
+
+    meas_in_df = pd.read_excel(XLSX_PATH, sheet_name=SHEET_NAME)
+    col_index = {name: i + 1 for i, name in enumerate(meas_in_df.columns)}
+
+    wb = openpyxl.load_workbook(XLSX_PATH)
+    ws = wb[SHEET_NAME]
+
+    diff_rows = []
+    for excel_row, (_, row) in enumerate(meas_in_df.iterrows(), start=2):
+        tier = tier_for_name(row.get("Name"))
+        if tier is None:
+            continue
+        # Multiple technologies in this row can share the same Energy
+        # Performance/Installed Cost/Lifetime cell (e.g. a combined
+        # heating+cooling package). Track each cell's contents here and
+        # chain edits through it -- writing straight from the original
+        # pandas row on every technology would make each technology's
+        # edit clobber the previous one's, since they'd all overwrite the
+        # same cell starting from its pre-edit text.
+        cell_state = {
+            "Energy Performance": row.get("Energy Performance"),
+            "Installed Cost": row.get("Installed Cost"),
+            "Lifetime": row.get("Lifetime"),
+        }
+        for tech in techs_for_row(row):
+            entry = crosswalk_by_tech_tier.get((tech, tier))
+            if entry is None:
+                continue
+            btb_row = get_btb_row(btb_data, entry)
+            if btb_row is None:
+                continue
+
+            # -- Performance --
+            perf_cell = cell_state["Energy Performance"]
+            units_cell = row.get("Performance Units")
+            target_unit = unit_for_tech(units_cell, tech)
+            metric_idx = None
+            for i in (1, 2):
+                if btb_row.get(f"Regression metric {i} - Metric") == \
+                        entry["btb_metric_name"]:
+                    metric_idx = i
+                    break
+            if target_unit and metric_idx:
+                raw_val = btb_row.get(
+                    f"Regression metric {metric_idx} - "
+                    f"{REGRESSION_BOUND_COL[entry['bound']]}")
+                converted = convert(
+                    entry["btb_metric_name"], target_unit, raw_val) \
+                    if pd.notna(raw_val) else None
+                if converted is not None:
+                    old_val = find_value_for_key(perf_cell, tech)
+                    new_val_str = f"{converted:.3g}"
+                    if old_val != new_val_str:
+                        cell_state["Energy Performance"] = \
+                            replace_value_for_key(
+                                perf_cell, tech, new_val_str)
+                        ws.cell(
+                            row=excel_row,
+                            column=col_index["Energy Performance"]).value \
+                            = cell_state["Energy Performance"]
+                        diff_rows.append({
+                            "Name": row.get("Name"), "technology": tech,
+                            "column": "Energy Performance",
+                            "old_value": old_val, "new_value": new_val_str,
+                            "btb_technology_id": entry["btb_technology_id"],
+                            "btb_display_name": entry["btb_display_name"],
+                            "projection_scenario":
+                                entry["projection_scenario"],
+                            "projection_year": entry["projection_year"],
+                        })
+
+            # -- Installed cost --
+            cost = compute_cost(btb_row, entry["bound"])
+            if cost is not None:
+                cost_cell = cell_state["Installed Cost"]
+                is_nested = isinstance(cost_cell, str) and ":" in cost_cell
+                tech_present = is_nested and re.search(
+                    re.escape(tech) + r"\s*:", cost_cell, re.IGNORECASE)
+                if not is_nested or tech_present:
+                    old_cost = find_value_for_key(cost_cell, tech)
+                    if is_zero_cost_placeholder(old_cost):
+                        diff_rows.append({
+                            "Name": row.get("Name"), "technology": tech,
+                            "column": "Installed Cost",
+                            "old_value": old_cost, "new_value": "(skipped)",
+                            "btb_technology_id": entry["btb_technology_id"],
+                            "btb_display_name": entry["btb_display_name"],
+                            "projection_scenario":
+                                entry["projection_scenario"],
+                            "projection_year": entry["projection_year"],
+                            "notes": "existing cost is $0 -- likely "
+                                     "intentionally shared with a paired "
+                                     "heating/cooling technology in this "
+                                     "row to avoid double-counting; left "
+                                     "unchanged, review manually",
+                        })
+                    else:
+                        new_full_cost_cell = replace_cost_for_key(
+                            cost_cell, tech, cost)
+                        new_cost_repr = (
+                            f"new: {cost['new']}; "
+                            f"existing: {cost['existing']}")
+                        if new_full_cost_cell != cost_cell:
+                            cell_state["Installed Cost"] = new_full_cost_cell
+                            ws.cell(
+                                row=excel_row,
+                                column=col_index["Installed Cost"]).value = \
+                                new_full_cost_cell
+                            diff_rows.append({
+                                "Name": row.get("Name"), "technology": tech,
+                                "column": "Installed Cost",
+                                "old_value": old_cost,
+                                "new_value": new_cost_repr,
+                                "btb_technology_id":
+                                    entry["btb_technology_id"],
+                                "btb_display_name":
+                                    entry["btb_display_name"],
+                                "projection_scenario":
+                                    entry["projection_scenario"],
+                                "projection_year": entry["projection_year"],
+                            })
+
+            # -- Lifetime --
+            lifetime = btb_row.get("Lifetime (Years)")
+            if pd.notna(lifetime):
+                lifetime_cell = cell_state["Lifetime"]
+                old_lifetime = find_value_for_key(lifetime_cell, tech)
+                new_lifetime_str = f"{float(lifetime):.3g}"
+                if old_lifetime != new_lifetime_str and (
+                        not isinstance(lifetime_cell, str)
+                        or ":" not in lifetime_cell
+                        or re.search(re.escape(tech) + r"\s*:",
+                                     lifetime_cell, re.IGNORECASE)):
+                    cell_state["Lifetime"] = replace_value_for_key(
+                        lifetime_cell, tech, new_lifetime_str)
+                    ws.cell(row=excel_row,
+                            column=col_index["Lifetime"]).value = \
+                        cell_state["Lifetime"]
+                    diff_rows.append({
+                        "Name": row.get("Name"), "technology": tech,
+                        "column": "Lifetime",
+                        "old_value": old_lifetime,
+                        "new_value": new_lifetime_str,
+                        "btb_technology_id": entry["btb_technology_id"],
+                        "btb_display_name": entry["btb_display_name"],
+                        "projection_scenario": entry["projection_scenario"],
+                        "projection_year": entry["projection_year"],
+                    })
+
+    if "BTB Diff" in wb.sheetnames:
+        del wb["BTB Diff"]
+    diff_ws = wb.create_sheet("BTB Diff")
+    diff_columns = [
+        "Name", "technology", "column", "old_value", "new_value",
+        "btb_technology_id", "btb_display_name", "projection_scenario",
+        "projection_year", "notes"]
+    diff_df = pd.DataFrame(diff_rows, columns=diff_columns).fillna("")
+    diff_ws.append(diff_columns)
+    for _, diff_row in diff_df.iterrows():
+        diff_ws.append(list(diff_row))
+
+    wb.save(OUT_PATH)
+    print(f"Proposed {len(diff_rows)} cell changes across "
+          f"{diff_df['Name'].nunique() if len(diff_df) else 0} measures.")
+    print(f"Wrote {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scout/supporting_data/btb/unit_conversions.py
+++ b/scout/supporting_data/btb/unit_conversions.py
@@ -1,0 +1,125 @@
+"""Convert BTB performance metrics into the units used in bss_meas_v2.xlsx.
+
+BTB reports a technology's primary performance metric under the
+"Regression metric {1,2} - Metric" column (e.g. "SEER1", "AFUE", "EER",
+"Heating COP", "UEF"), with an accompanying "... - Unit" column that is
+often just "Unitless" or "Btu/W" rather than the metric name itself -- so
+matching must key off the *metric name*, not the unit string.
+
+Within `meas_in`, "COP", "AFUE", and "BTU out/BTU in" are all the same
+underlying dimensionless output/input energy ratio -- just labeled
+differently depending on which row/end-use they show up in (a row mixing
+combustion and compression equipment, e.g. a gas boiler + electric
+chiller package, labels both "BTU out/BTU in" even though one behaves
+like an AFUE and the other like a COP). This mirrors Scout's own
+unit-conversion table for ECM performance data (`HandyVars.tech_units_map`
+in scout/ecm_prep_vars.py), which treats AFUE as numerically equivalent to
+COP (`"AFUE": {"COP": 1}`) and establishes that SEER/EER/CEER/HSPF-type
+metrics -- expressed in Btu of output per watt-hour of input -- convert to
+that same dimensionless ratio by dividing by 3.412 (Btu/hr per W; see
+`"EER": {"COP": 3.412}` there). That Btu/Wh relationship holds regardless
+of the specific metric's name (SEER, SEER2, EER, CEER, HSPF, HSPF2 are all
+seasonal or point-in-time variants of the same Btu/Wh basis), so one
+conversion factor covers all of them here.
+
+Because the target unit is whatever the destination `meas_in` cell already
+uses (not a fixed label per technology), `convert()` takes that target
+unit explicitly rather than deciding one itself.
+
+BTB itself reports AFUE on a 0-100 percentage scale (e.g. Typical = 90.0
+for a gas furnace, confirmed against raw BTB residential data for
+Technology ID 91), while `meas_in` stores it as a 0-1 fraction (e.g. 0.9)
+-- this is unrelated to the AFUE/COP unit-label equivalence above and is
+handled separately (see PERCENT_METRICS).
+
+Only metrics actually observed in the BTB rows relevant to the
+BTB-covered `meas_in` categories (HVAC, Water Heating, Lighting,
+Refrigeration, Cooking) are included. Anything not listed here is left for
+build_tech_crosswalk.py to flag `needs_review` rather than guessed at.
+"""
+
+# Btu of cooling/heating output per watt-hour of electrical input ->
+# dimensionless ratio. Source: scout/ecm_prep_vars.py
+# HandyVars.tech_units_map ("EER": {"COP": 3.412}).
+BTU_PER_WH_TO_RATIO = 3.412
+
+# meas_in unit labels that are all the same dimensionless output/input
+# energy ratio (see module docstring).
+RATIO_UNIT_LABELS = {"cop", "afue", "btu out/btu in"}
+
+# BTB "Regression metric - Metric" names reported in Btu/Wh (seasonal or
+# point-in-time) that convert to the ratio labels above by dividing by
+# BTU_PER_WH_TO_RATIO.
+BTU_PER_WH_METRICS = {
+    "seer", "seer1", "seer2", "eer", "ceer", "hspf", "hspf2",
+}
+
+# BTB "Regression metric - Metric" names that are already a dimensionless
+# ratio (0-1-ish scale, e.g. a COP) and need no conversion to reach a
+# ratio-labeled target unit.
+RATIO_METRICS = {"heating cop", "cooling cop"}
+
+# BTB "Regression metric - Metric" names reported as a 0-100 percentage
+# (e.g. AFUE Typical value of 90, meaning 90%) that meas_in instead stores
+# as a 0-1 fraction -- confirmed against the raw BTB residential furnace
+# data (Technology ID 91, "AFUE" Typical = 90.0).
+PERCENT_METRICS = {"afue"}
+
+# BTB metric name -> meas_in unit label, for metrics with their own
+# dedicated (non-ratio) unit that BTB and meas_in both use as-is.
+DIRECT_PASSTHROUGH_METRICS = {
+    "uef": "UEF", "sef": "UEF", "suef": "UEF", "cef": "CEF",
+    "efficacy": "lm/W",
+}
+
+
+def normalize(name):
+    """Lowercase/strip a metric or unit string for lookup."""
+
+    if not isinstance(name, str):
+        return None
+    return name.strip().lower()
+
+
+def convert(metric_name, target_unit, value):
+    """Convert a BTB performance value into a specific meas_in unit.
+
+    Args:
+        metric_name (str): Raw value from a BTB "Regression metric -
+            Metric" column (e.g. "SEER1", "Heating COP").
+        target_unit (str): The unit label already used in the destination
+            meas_in cell (e.g. "COP", "AFUE", "BTU out/BTU in", "UEF").
+        value (float): The BTB performance value (e.g. a Typical/Lower
+            Bound/Upper Bound regression output) to convert.
+
+    Returns:
+        The converted value (float), or None if no conversion rule is
+        known for this metric/target-unit pair -- callers should treat
+        that case as needing manual review rather than assuming a
+        passthrough.
+    """
+
+    metric = normalize(metric_name)
+    target = normalize(target_unit)
+    if metric is None or target is None:
+        return None
+
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if target in RATIO_UNIT_LABELS:
+        if metric in BTU_PER_WH_METRICS:
+            return value / BTU_PER_WH_TO_RATIO
+        if metric in RATIO_METRICS:
+            return value
+        if metric in PERCENT_METRICS:
+            return value / 100
+        return None
+
+    if metric in DIRECT_PASSTHROUGH_METRICS and \
+            DIRECT_PASSTHROUGH_METRICS[metric].lower() == target:
+        return value
+
+    return None


### PR DESCRIPTION
## Summary
- Adds a 3-step pipeline under `scout/supporting_data/btb/` (download →
  build/review a technology crosswalk → propose values) that sources
  Energy Performance/Installed Cost/Lifetime data for `meas_in` directly
  from NREL's published Buildings Technology Baseline (BTB) dataset on
  OpenEI, in place of hand-transcribing from a Google Sheet.
- Covers the categories BTB has clear technology-level cost/performance
  data for (HVAC, Water Heating, Lighting, Refrigeration, Cooking, both
  residential and commercial) via an explicit, auditable keyword rule
  table (`build_tech_crosswalk.py`), currently covering 48 of the ~100
  technology tokens used in `meas_in`. Envelope and electronics/MELs
  tokens have no BTB coverage and are left untouched.
- Never edits `bss_meas_v2.xlsx` directly — `populate_meas_in_from_btb.py`
  writes a separate `bss_meas_v2_btb_proposed.xlsx` with a `BTB Diff`
  sheet (old value, proposed value, matched BTB source row) for manual
  review before merging any change back into the curated original.
- Includes a small unit-conversion table (`unit_conversions.py`) that
  reuses the same Btu/Wh→COP factor (3.412) already established in
  `scout/ecm_prep_vars.py`'s `tech_units_map`, and a couple of data-quality
  safeguards found while validating against the existing sheet: BTB
  reports AFUE on a 0–100 scale where `meas_in` expects 0–1, and a `$0`
  cost in the original sheet usually signals equipment intentionally
  shared with a paired heating/cooling technology (to avoid
  double-counting) rather than a value to overwrite.

## Test plan
- [x] `python download_btb_data.py` — downloads both BTB CSVs
- [x] `python build_tech_crosswalk.py` — writes `tech_crosswalk.csv`,
      spot-checked against known technologies (central AC, furnace (NG),
      ASHP, boiler (NG), HPWH, several commercial HVAC/refrigeration types)
<img width="1601" height="270" alt="image" src="https://github.com/user-attachments/assets/ec44ab49-2074-4788-a703-8285024b6135" />

- [x] `python populate_meas_in_from_btb.py` — writes
      `bss_meas_v2_btb_proposed.xlsx`; spot-checked several `BTB Diff` rows
      against the existing hand-entered values in `bss_meas_v2.xlsx`
      (e.g. NG furnace AFUE, ASHP performance) — BTB-derived values match
      where the original was already BTB-sourced

The BTB Diff sheet indicates what changes are made
<img width="1445" height="297" alt="image" src="https://github.com/user-attachments/assets/f6f8e738-2d36-49b9-8843-47288ba77681" />

- [ ] Domain-expert review of `tech_crosswalk.csv` tier defaults
      (Ref. Case/Min. Efficiency/ESTAR/Best → BTB scenario/bound mapping)
      before treating any proposed value as final
